### PR TITLE
feat: add wire-protocol compatibility with msgpackr for undefined values

### DIFF
--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -62,9 +62,10 @@ export type EncoderOptions<ContextType = undefined> = Partial<
 
     /**
      * If `true`, undefineds are not handled by the library and are instead
-     * made available to extension codecs
+     * made available to extension codecs.
      *
-     * Defaults to `false`
+     * Defaults to `true` for wire-protocol compatibility with msgpackr,
+     * which encodes `undefined` as fixext1 type 0.
      */
     allowUndefinedCustomEncoding: boolean;
 
@@ -105,7 +106,7 @@ export class Encoder<ContextType = undefined> {
     this.sortKeys = options?.sortKeys ?? false;
     this.forceFloat32 = options?.forceFloat32 ?? false;
     this.ignoreUndefined = options?.ignoreUndefined ?? false;
-    this.allowUndefinedCustomEncoding = options?.allowUndefinedCustomEncoding ?? false;
+    this.allowUndefinedCustomEncoding = options?.allowUndefinedCustomEncoding ?? true;
     this.forceIntegerToFloat = options?.forceIntegerToFloat ?? false;
 
     this.pos = 0;

--- a/src/ExtensionCodec.ts
+++ b/src/ExtensionCodec.ts
@@ -2,6 +2,7 @@
 
 import { ExtData } from "./ExtData";
 import { timestampExtension } from "./timestamp";
+import { undefinedExtension } from "./undefined";
 
 export type ExtensionDecoderType<ContextType> = (
   data: Uint8Array,
@@ -37,6 +38,7 @@ export class ExtensionCodec<ContextType = undefined> implements ExtensionCodecTy
 
   public constructor() {
     this.register(timestampExtension);
+    this.register(undefinedExtension);
   }
 
   public register({

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,3 +50,14 @@ export {
   encodeTimestampExtension,
   decodeTimestampExtension,
 };
+
+import {
+  EXT_UNDEFINED,
+  encodeUndefinedExtension,
+  decodeUndefinedExtension,
+} from "./undefined";
+export {
+  EXT_UNDEFINED,
+  encodeUndefinedExtension,
+  decodeUndefinedExtension,
+};

--- a/src/undefined.ts
+++ b/src/undefined.ts
@@ -1,0 +1,22 @@
+// Extension type 0 for undefined values
+// This is compatible with msgpackr's wire format, which uses fixext1 type 0 to represent undefined.
+// See: https://github.com/kriszyp/msgpackr
+
+export const EXT_UNDEFINED = 0;
+
+export function encodeUndefinedExtension(object: unknown): Uint8Array | null {
+  if (object === undefined) {
+    return new Uint8Array(1); // single zero byte, encoded as fixext1 type 0
+  }
+  return null;
+}
+
+export function decodeUndefinedExtension(_data: Uint8Array): undefined {
+  return undefined;
+}
+
+export const undefinedExtension = {
+  type: EXT_UNDEFINED,
+  encode: encodeUndefinedExtension,
+  decode: decodeUndefinedExtension,
+};

--- a/test/encode.test.ts
+++ b/test/encode.test.ts
@@ -50,15 +50,22 @@ describe("encode", () => {
   });
 
   context("ignoreUndefined", () => {
-    it("encodes { foo: undefined } as is by default", () => {
-      assert.deepStrictEqual(decode(encode({ foo: undefined, bar: 42 })), { foo: null, bar: 42 });
+    it("encodes { foo: undefined } as undefined by default (via ext type 0, msgpackr-compatible)", () => {
+      assert.deepStrictEqual(decode(encode({ foo: undefined, bar: 42 })), { foo: undefined, bar: 42 });
     });
 
-    it("encodes { foo: undefined } as is with `ignoreUndefined: false`", () => {
+    it("encodes { foo: undefined } as undefined with `ignoreUndefined: false`", () => {
       assert.deepStrictEqual(decode(encode({ foo: undefined, bar: 42 }, { ignoreUndefined: false })), {
-        foo: null,
+        foo: undefined,
         bar: 42,
       });
+    });
+
+    it("encodes { foo: undefined } as null with `allowUndefinedCustomEncoding: false`", () => {
+      assert.deepStrictEqual(
+        decode(encode({ foo: undefined, bar: 42 }, { allowUndefinedCustomEncoding: false })),
+        { foo: null, bar: 42 },
+      );
     });
 
     it("encodes { foo: undefined } to {} with `ignoreUndefined: true`", () => {

--- a/test/interop-test.ts
+++ b/test/interop-test.ts
@@ -1,0 +1,96 @@
+// Interop test: verify wire-protocol compatibility between @gathertown/msgpack and msgpackr
+import assert from "assert";
+import { encode, decode } from "../src";
+import { unpack, Packr } from "msgpackr";
+
+describe("msgpackr interop", () => {
+  const packr = new Packr({ useRecords: false });
+
+  context("undefined encoding", () => {
+    it("@gathertown/msgpack encode → msgpackr decode: bare undefined", () => {
+      const encoded = encode(undefined);
+      const decoded = unpack(encoded);
+      assert.strictEqual(decoded, undefined);
+    });
+
+    it("msgpackr encode → @gathertown/msgpack decode: bare undefined", () => {
+      const encoded = packr.pack(undefined);
+      const decoded = decode(encoded);
+      assert.strictEqual(decoded, undefined);
+    });
+
+    it("wire format matches for undefined", () => {
+      const gtEncoded = encode(undefined);
+      const mrEncoded = packr.pack(undefined);
+      const mrBytes = new Uint8Array(mrEncoded.buffer, mrEncoded.byteOffset, mrEncoded.byteLength);
+      assert.deepStrictEqual(Array.from(gtEncoded), Array.from(mrBytes));
+    });
+  });
+
+  context("objects with undefined values", () => {
+    it("@gathertown/msgpack encode → msgpackr decode", () => {
+      const obj = { a: 1, b: undefined, c: "hello" };
+      const encoded = encode(obj);
+      const decoded = unpack(encoded) as any;
+      assert.strictEqual(decoded.a, 1);
+      assert.strictEqual(decoded.b, undefined);
+      assert.strictEqual(decoded.c, "hello");
+    });
+
+    it("msgpackr encode → @gathertown/msgpack decode", () => {
+      const obj = { a: 1, b: undefined, c: "hello" };
+      const encoded = packr.pack(obj);
+      const decoded = decode(encoded) as any;
+      assert.strictEqual(decoded.a, 1);
+      assert.strictEqual(decoded.b, undefined);
+      assert.strictEqual(decoded.c, "hello");
+    });
+  });
+
+  context("arrays with undefined values", () => {
+    it("@gathertown/msgpack encode → msgpackr decode", () => {
+      const arr = [1, undefined, "hello", null, undefined];
+      const encoded = encode(arr);
+      const decoded = unpack(encoded) as any[];
+      assert.strictEqual(decoded[0], 1);
+      assert.strictEqual(decoded[1], undefined);
+      assert.strictEqual(decoded[2], "hello");
+      assert.strictEqual(decoded[3], null);
+      assert.strictEqual(decoded[4], undefined);
+    });
+
+    it("msgpackr encode → @gathertown/msgpack decode", () => {
+      const arr = [1, undefined, "hello", null, undefined];
+      const encoded = packr.pack(arr);
+      const decoded = decode(encoded) as any[];
+      assert.strictEqual(decoded[0], 1);
+      assert.strictEqual(decoded[1], undefined);
+      assert.strictEqual(decoded[2], "hello");
+      assert.strictEqual(decoded[3], null);
+      assert.strictEqual(decoded[4], undefined);
+    });
+  });
+
+  context("null vs undefined distinction", () => {
+    it("null and undefined produce different wire formats", () => {
+      const nullEncoded = encode(null);
+      const undefinedEncoded = encode(undefined);
+      // null is 0xc0 (nil), undefined is 0xd4 0x00 0x00 (fixext1 type 0)
+      assert.notDeepStrictEqual(Array.from(nullEncoded), Array.from(undefinedEncoded));
+    });
+
+    it("null round-trips as null, undefined round-trips as undefined", () => {
+      assert.strictEqual(decode(encode(null)), null);
+      assert.strictEqual(decode(encode(undefined)), undefined);
+    });
+
+    it("cross-library: null/undefined distinction preserved", () => {
+      // @gathertown/msgpack → msgpackr
+      assert.strictEqual(unpack(encode(null)), null);
+      assert.strictEqual(unpack(encode(undefined)), undefined);
+      // msgpackr → @gathertown/msgpack
+      assert.strictEqual(decode(packr.pack(null)), null);
+      assert.strictEqual(decode(packr.pack(undefined)), undefined);
+    });
+  });
+});

--- a/test/msgpack-ext.test.ts
+++ b/test/msgpack-ext.test.ts
@@ -10,15 +10,16 @@ function seq(n: number) {
 }
 
 describe("msgpack-ext", () => {
+  // Use ext type 2 (not 0, which is reserved for the built-in undefined extension)
   const SPECS = {
-    FIXEXT1: [0xd4, new ExtData(0, seq(1))],
-    FIXEXT2: [0xd5, new ExtData(0, seq(2))],
-    FIXEXT4: [0xd6, new ExtData(0, seq(4))],
-    FIXEXT8: [0xd7, new ExtData(0, seq(8))],
-    FIXEXT16: [0xd8, new ExtData(0, seq(16))],
-    EXT8: [0xc7, new ExtData(0, seq(17))],
-    EXT16: [0xc8, new ExtData(0, seq(0x100))],
-    EXT32: [0xc9, new ExtData(0, seq(0x10000))],
+    FIXEXT1: [0xd4, new ExtData(2, seq(1))],
+    FIXEXT2: [0xd5, new ExtData(2, seq(2))],
+    FIXEXT4: [0xd6, new ExtData(2, seq(4))],
+    FIXEXT8: [0xd7, new ExtData(2, seq(8))],
+    FIXEXT16: [0xd8, new ExtData(2, seq(16))],
+    EXT8: [0xc7, new ExtData(2, seq(17))],
+    EXT16: [0xc8, new ExtData(2, seq(0x100))],
+    EXT32: [0xc9, new ExtData(2, seq(0x10000))],
   } as Record<string, [number, ExtData]>;
 
   for (const name of Object.keys(SPECS)) {


### PR DESCRIPTION
## Goal

Make `@gathertown/msgpack-javascript` wire-protocol compatible with [msgpackr](https://github.com/kriszyp/msgpackr) for `undefined` values.

msgpackr encodes `undefined` using MessagePack extension type 0 (fixext1 format: `0xd4 0x00 0x00`). This library previously encoded `undefined` as `nil` (`0xc0`), which loses the distinction between `null` and `undefined` on round-trip.

## Changes

- **New `src/undefined.ts`**: Defines extension type 0 handler matching msgpackr wire format
  - Encoder returns single zero byte for `undefined`
  - Decoder returns `undefined` for ext type 0
- **`src/ExtensionCodec.ts`**: Register `undefinedExtension` as built-in alongside `timestampExtension`
- **`src/Encoder.ts`**: Change `allowUndefinedCustomEncoding` default from `false` to `true` so undefined routes through the extension codec by default
- **`src/index.ts`**: Export `EXT_UNDEFINED`, `encodeUndefinedExtension`, `decodeUndefinedExtension`
- **Tests updated**: Reflect new undefined round-trip behavior and reserve ext type 0
- **New `test/interop-test.ts`**: 10 cross-library interop tests verifying wire compatibility with msgpackr

## Backward Compatibility

Users can restore the old behavior with `{ allowUndefinedCustomEncoding: false }` to encode undefined as nil.

## Test Plan

- [x] All 318 existing tests pass (with updated expectations)
- [x] Lint passes
- [x] CI passes
- [x] Verify msgpackr can decode data encoded by this library (undefined round-trips correctly)
- [x] Verify this library can decode msgpackr-encoded undefined values

Requested by @bgreenier

[Devin Session](https://app.devin.ai/sessions/f2a34d467f9b42fc86efb1cc7e485e9f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 3fd0c6f6f9f735feec08307a4cef0b5659b31b32. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->