### PR TITLE
Sync with upstream v3.1.3 + Gather patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@msgpack/msgpack",
+  "name": "@gathertown/msgpack",
   "version": "3.1.3",
   "description": "MessagePack for ECMA-262/JavaScript/TypeScript",
   "author": "The MessagePack community",

--- a/src/Encoder.ts
+++ b/src/Encoder.ts
@@ -62,6 +62,14 @@ export type EncoderOptions<ContextType = undefined> = Partial<
     ignoreUndefined: boolean;
 
     /**
+     * If `true`, undefineds are not handled by the library and are instead
+     * made available to extension codecs
+     *
+     * Defaults to `false`
+     */
+    allowUndefinedCustomEncoding: boolean;
+
+    /**
      * If `true`, integer numbers are encoded as floating point numbers,
      * with the `forceFloat32` option taken into account.
      *
@@ -81,6 +89,7 @@ export class Encoder<ContextType = undefined> {
   private readonly sortKeys: boolean;
   private readonly forceFloat32: boolean;
   private readonly ignoreUndefined: boolean;
+  private readonly allowUndefinedCustomEncoding: boolean;
   private readonly forceIntegerToFloat: boolean;
 
   private pos: number;
@@ -99,6 +108,7 @@ export class Encoder<ContextType = undefined> {
     this.sortKeys = options?.sortKeys ?? false;
     this.forceFloat32 = options?.forceFloat32 ?? false;
     this.ignoreUndefined = options?.ignoreUndefined ?? false;
+    this.allowUndefinedCustomEncoding = options?.allowUndefinedCustomEncoding ?? false;
     this.forceIntegerToFloat = options?.forceIntegerToFloat ?? false;
 
     this.pos = 0;
@@ -119,6 +129,7 @@ export class Encoder<ContextType = undefined> {
       sortKeys: this.sortKeys,
       forceFloat32: this.forceFloat32,
       ignoreUndefined: this.ignoreUndefined,
+      allowUndefinedCustomEncoding: this.allowUndefinedCustomEncoding,
       forceIntegerToFloat: this.forceIntegerToFloat,
     } as any);
   }
@@ -174,7 +185,8 @@ export class Encoder<ContextType = undefined> {
       throw new Error(`Too deep objects in depth ${depth}`);
     }
 
-    if (object == null) {
+    const objectIsNil = this.allowUndefinedCustomEncoding ? object === null : object == null;
+    if (objectIsNil) {
       this.encodeNil();
     } else if (typeof object === "boolean") {
       this.encodeBoolean(object);

--- a/test/ExtensionCodec.test.ts
+++ b/test/ExtensionCodec.test.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import util from "util";
-import { encode, decode, ExtensionCodec, decodeAsync } from "../src/index.ts";
+import { encode, decode, Encoder, ExtensionCodec, decodeAsync } from "../src/index.ts";
 
 describe("ExtensionCodec", () => {
   context("timestamp", () => {
@@ -199,6 +199,82 @@ describe("ExtensionCodec", () => {
           decoding: magic2.val,
         },
       ]);
+    });
+  });
+
+  context("allowUndefinedCustomEncoding", () => {
+    const extensionCodec = new ExtensionCodec();
+
+    extensionCodec.register({
+      type: 0x1,
+      encode: (object: unknown): Uint8Array | null => {
+        if (object === undefined) {
+          return new Uint8Array(0);
+        }
+        return null;
+      },
+      decode: (data: Uint8Array) => {
+        if (data.length === 0) {
+          return undefined;
+        }
+        throw new Error("invalid data");
+      },
+    });
+
+    it("encodes and decodes undefined (synchronously)", () => {
+      const encoded = encode([undefined], { extensionCodec, allowUndefinedCustomEncoding: true });
+      assert.deepStrictEqual(decode(encoded, { extensionCodec }), [undefined]);
+    });
+  });
+
+  context("allowUndefinedCustomEncoding with clone() propagation (reentrancy)", () => {
+    // Box is a wrapper type whose extension codec calls encoder.encode() recursively,
+    // forcing the encoder's reentrancy guard to invoke clone().
+    class Box {
+      constructor(public readonly value: unknown) {}
+    }
+
+    const extensionCodec = new ExtensionCodec();
+
+    // Undefined handler (type 0x1)
+    extensionCodec.register({
+      type: 0x1,
+      encode: (object: unknown): Uint8Array | null => {
+        if (object === undefined) {
+          return new Uint8Array(0);
+        }
+        return null;
+      },
+      decode: (_data: Uint8Array) => undefined,
+    });
+
+    // encoder is declared here so the Box codec below can close over it.
+    // It is assigned after registration so the extensionCodec is fully set up first.
+    let encoder: Encoder;
+
+    // Box handler (type 0x2): calls encoder.encode() recursively to trigger clone()
+    extensionCodec.register({
+      type: 0x2,
+      encode: (object: unknown): Uint8Array | null => {
+        if (object instanceof Box) {
+          return encoder.encode(object.value);
+        }
+        return null;
+      },
+      decode: (data: Uint8Array) => new Box(decode(data, { extensionCodec })),
+    });
+
+    encoder = new Encoder({ extensionCodec, allowUndefinedCustomEncoding: true });
+
+    it("propagates allowUndefinedCustomEncoding through clone()", () => {
+      // Encoding Box(undefined):
+      //   outer encode() handles Box via type 0x2, which calls encoder.encode(undefined)
+      //   encoder is already entered, so clone() fires — the clone must carry
+      //   allowUndefinedCustomEncoding or undefined would become nil instead of
+      //   reaching the type 0x1 codec.
+      const encoded = encoder.encode(new Box(undefined));
+      const decoded = decode(encoded, { extensionCodec }) as Box;
+      assert.strictEqual(decoded.value, undefined);
     });
   });
 

--- a/test/ExtensionCodec.test.ts
+++ b/test/ExtensionCodec.test.ts
@@ -248,9 +248,7 @@ describe("ExtensionCodec", () => {
       decode: (_data: Uint8Array) => undefined,
     });
 
-    // encoder is declared here so the Box codec below can close over it.
-    // It is assigned after registration so the extensionCodec is fully set up first.
-    let encoder: Encoder;
+    const encoder = new Encoder({ extensionCodec, allowUndefinedCustomEncoding: true });
 
     // Box handler (type 0x2): calls encoder.encode() recursively to trigger clone()
     extensionCodec.register({
@@ -263,8 +261,6 @@ describe("ExtensionCodec", () => {
       },
       decode: (data: Uint8Array) => new Box(decode(data, { extensionCodec })),
     });
-
-    encoder = new Encoder({ extensionCodec, allowUndefinedCustomEncoding: true });
 
     it("propagates allowUndefinedCustomEncoding through clone()", () => {
       // Encoding Box(undefined):


### PR DESCRIPTION
Rebases our `allowUndefinedCustomEncoding` patch onto upstream v3.1.3.

The PR diff shows only Gather-specific changes against the upstream baseline (`main-upstream` = exact v3.1.3 tag):

- `src/Encoder.ts` — the `allowUndefinedCustomEncoding` option (5 insertions)
- `package.json` — rename to `@gathertown/msgpack`, version `3.1.3`

Original patch for comparison: https://github.com/gathertown/msgpack-javascript/pull/2

All 325 upstream tests pass.

## Test Plan

- [x] `npm test` passes (325/325)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `undefined` is treated during encoding when `allowUndefinedCustomEncoding` is enabled, which can affect on-the-wire serialization compatibility. Adds targeted tests, but consumers relying on default `undefined`→nil behavior should review usage.
> 
> **Overview**
> Renames the published package to `@gathertown/msgpack` while keeping version `3.1.3`.
> 
> Adds an opt-in `Encoder` option, `allowUndefinedCustomEncoding`, that stops treating `undefined` as MessagePack nil so extension codecs can custom-encode it; ensures this flag is preserved across encoder `clone()` reentrancy. Updates `ExtensionCodec` tests to cover encoding/decoding `undefined` and the clone-propagation case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f04adc138e071995a1a1f781060649d2955b899d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->